### PR TITLE
Add damage + player healthbar that decrements

### DIFF
--- a/Assets/Scripts/Enemy.cs
+++ b/Assets/Scripts/Enemy.cs
@@ -8,8 +8,6 @@ public class Enemy : MonoBehaviour
     [SerializeField]
     private int _damageToPlayer = 10; // unused, but just an example of how this could be set/accessed
 
-    void Start() { }
-
     // Update is called once per frame
     void Update()
     {

--- a/Assets/Scripts/HealthBar.cs
+++ b/Assets/Scripts/HealthBar.cs
@@ -1,0 +1,28 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class HealthBar : MonoBehaviour
+{
+
+    private Slider _slider;
+    // Start is called before the first frame update
+    void Start()
+    {
+        _slider = GetComponent<Slider>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+
+    // 0.0f = 0% health, 1.0f = 100% health
+    public void SetHealth(float health)
+    {
+        Debug.Log("HealthBar.SetHealth: Setting health to " + health);
+        _slider.value = health;
+    }
+}

--- a/Assets/Scripts/HealthBar.cs.meta
+++ b/Assets/Scripts/HealthBar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9d051a174872c4487b6c7f3d03646926
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -8,8 +8,13 @@ public class Player : MonoBehaviour
 {
     [SerializeField] private int _hitPoints = 100;
 
+    private HealthBar _healthBar;
+
     // Start is called before the first frame update
-    void Start() { }
+    void Start() { 
+        // get a reference to the Healthbar component
+        _healthBar = GameObject.Find("HealthBar").GetComponent<HealthBar>();
+    }
 
     // Update is called once per frame
     void Update()
@@ -31,6 +36,7 @@ public class Player : MonoBehaviour
         _hitPoints -= damage;
         _hitPoints = Math.Max(_hitPoints, 0); // don't let the player have negative hit points
 
+        _healthBar.SetHealth(_hitPoints / 100f);
         Debug.Log("Player.TakeDamage: Player took " + damage + " damage and now has " + _hitPoints + " hit points");
     }
 }


### PR DESCRIPTION
- Player now takes damage when colliding with Enemy
- Add HealthBar UI + script that's just a single red image fill
- Player damage reduces fill on HealthBar

Screenshot of a Player that has already received damage by colliding with an enemy and is now at 90% health:

![image](https://github.com/getsentry/sentaur-survivors/assets/2153/b8e6bd23-db27-4515-bb58-fb8d9ca0d78c)
