### PR TITLE
feat: controller support

### DIFF
--- a/Assets/Scripts/Characters/Arrow.cs
+++ b/Assets/Scripts/Characters/Arrow.cs
@@ -1,19 +1,22 @@
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 public class Arrow : MonoBehaviour
 {
     [SerializeField] private bool _forceEnable;
+    
     private void Awake()
     {
         if (_forceEnable)
         {
             return;
         }
-            
-        if (Application.platform != RuntimePlatform.Android && 
-            Application.platform != RuntimePlatform.IPhonePlayer)
-        {
-            gameObject.SetActive(false);    
-        }
+        
+        // Show arrow on mobile platforms or when a gamepad is connected
+        bool shouldShowArrow = Application.platform == RuntimePlatform.Android || 
+                               Application.platform == RuntimePlatform.IPhonePlayer ||
+                               Gamepad.current != null;
+        
+        gameObject.SetActive(shouldShowArrow);
     }
 }

--- a/Assets/Scripts/SceneManagers/BattleSceneManager.cs
+++ b/Assets/Scripts/SceneManagers/BattleSceneManager.cs
@@ -463,6 +463,12 @@ public class BattleSceneManager : MonoBehaviour
 
     public void OnPause()
     {
+        // Don't allow pausing if the level up UI is active (it already pauses the game)
+        if (_levelUpUI.activeSelf)
+        {
+            return;
+        }
+        
         if (_gameState == GameState.Playing)
         {
             PauseGame();

--- a/Assets/Scripts/SceneManagers/HUDManager.cs
+++ b/Assets/Scripts/SceneManagers/HUDManager.cs
@@ -23,11 +23,19 @@ namespace SceneManagers
             _navigateAction = InputSystem.actions.FindAction("Navigate");
             _submitAction = InputSystem.actions.FindAction("Submit");
             
-            // Subscribe to the performed callback only
+            // Subscribe to input events
+            _navigateAction.performed += OnNavigatePerformed;
             _submitAction.performed += OnSubmitPerformed;
             
             _tryAgainHighlighter = tryAgainButton.GetComponent<Highlighter>();
             _quitHighlighter = quitButton.GetComponent<Highlighter>();
+        }
+        
+        private void OnDestroy()
+        {
+            // Unsubscribe from input events
+            _navigateAction.performed -= OnNavigatePerformed;
+            _submitAction.performed -= OnSubmitPerformed;
         }
 
         private void OnSubmitPerformed(InputAction.CallbackContext context)
@@ -40,7 +48,7 @@ namespace SceneManagers
             _highlightedButton?.GetComponent<Button>().onClick.Invoke();
         }
 
-        public void OnNavigate()
+        private void OnNavigatePerformed(InputAction.CallbackContext context)
         {
             if (!gameObject.activeSelf)
             {
@@ -52,12 +60,7 @@ namespace SceneManagers
                 return;
             }
 
-            if (!_navigateAction.WasPressedThisFrame())
-            {
-                return;
-            }
-
-            var direction = _navigateAction.ReadValue<Vector2>();
+            var direction = context.ReadValue<Vector2>();
             
             // Simple navigation between try again and quit buttons
             if (_highlightedButton == null)

--- a/Assets/Scripts/SceneManagers/HUDManager.cs
+++ b/Assets/Scripts/SceneManagers/HUDManager.cs
@@ -45,7 +45,11 @@ namespace SceneManagers
                 return;
             }
             
-            _highlightedButton?.GetComponent<Button>().onClick.Invoke();
+            // Only invoke if the highlighted button is actually active
+            if (_highlightedButton != null && _highlightedButton.activeSelf)
+            {
+                _highlightedButton.GetComponent<Button>().onClick.Invoke();
+            }
         }
 
         private void OnNavigatePerformed(InputAction.CallbackContext context)
@@ -94,6 +98,13 @@ namespace SceneManagers
         
             highlighted.Highlight();
             _highlightedButton = highlighted.gameObject;
+        }
+        
+        public void ClearHighlightedButton()
+        {
+            _tryAgainHighlighter.Highlight(false);
+            _quitHighlighter.Highlight(false);
+            _highlightedButton = null;
         }
     }
 }

--- a/Assets/Scripts/UI/HUD/HUD.cs
+++ b/Assets/Scripts/UI/HUD/HUD.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using SceneManagers;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -16,6 +17,7 @@ public class HUD : MonoBehaviour
     [SerializeField] private ScorePoster _scorePoster;
     [SerializeField] private GameObject _tryAgain;
     [SerializeField] private GameObject _quit;
+    [SerializeField] private HUDManager _hudManager;
 
     private DemoConfiguration _demoConfig;
     private XpBar _xpBar;

--- a/Assets/Scripts/UI/HUD/HUD.cs
+++ b/Assets/Scripts/UI/HUD/HUD.cs
@@ -80,6 +80,12 @@ public class HUD : MonoBehaviour
         _gameOverText.enabled = false;
         _tryAgain.SetActive(false);
         _quit.SetActive(false);
+        
+        // Clear the highlighted button to prevent accidental clicks
+        if (_hudManager != null)
+        {
+            _hudManager.ClearHighlightedButton();
+        }
     }
 
     public void ShowGameOver()

--- a/Assets/Scripts/Upgrades/LevelUpUI.cs
+++ b/Assets/Scripts/Upgrades/LevelUpUI.cs
@@ -49,6 +49,10 @@ namespace Upgrades
             InputSystem.actions.FindActionMap("Player").Disable();
             InputSystem.actions.FindActionMap("UI").Enable();
             
+            // Subscribe to input events
+            _navigateAction.performed += OnNavigatePerformed;
+            _submitAction.performed += OnSubmitPerformed;
+            
             // Pause the game
             Time.timeScale = 0;
 
@@ -75,6 +79,9 @@ namespace Upgrades
 
             _option1Button.onClick.AddListener(() => SelectUpgrade(upgradeChoice1));
             _option2Button.onClick.AddListener(() => SelectUpgrade(upgradeChoice2));
+            
+            // Set initial highlighted button to option 1
+            SetHighlightedButton(_option1Button);
 
             if (_demoConfig != null && _demoConfig.AutoPlay)
             {
@@ -107,19 +114,14 @@ namespace Upgrades
             _highlightedButton?.GetComponent<Button>().onClick.Invoke();
         }
         
-        public void OnNavigate()
+        private void OnNavigatePerformed(InputAction.CallbackContext context)
         {
             if (!gameObject.activeSelf)
             {
                 return;
             }
             
-            if (!_navigateAction.WasPressedThisFrame())
-            {
-                return;
-            }
-            
-            var direction = _navigateAction.ReadValue<Vector2>();
+            var direction = context.ReadValue<Vector2>();
             if (direction.x < 0)
             {
                 SetHighlightedButton(_option1Button);
@@ -130,19 +132,14 @@ namespace Upgrades
             }
         }
         
-        public void OnSubmit()
+        private void OnSubmitPerformed(InputAction.CallbackContext context)
         {
             if (!gameObject.activeSelf)
             {
                 return;
             }
             
-            if (!_submitAction.IsPressed())
-            {
-                return;
-            }
-            
-            _highlightedButton?.GetComponent<Button>().onClick.Invoke();
+            _highlightedButton?.onClick.Invoke();
         }
 
         public void SetHighlightedButton(Button button)
@@ -156,6 +153,10 @@ namespace Upgrades
 
         private void OnDisable()
         {
+            // Unsubscribe from input events
+            _navigateAction.performed -= OnNavigatePerformed;
+            _submitAction.performed -= OnSubmitPerformed;
+            
             _option1Button.onClick.RemoveAllListeners();
             _option2Button.onClick.RemoveAllListeners();
         }

--- a/Assets/Settings/InputSystem_Actions.inputactions
+++ b/Assets/Settings/InputSystem_Actions.inputactions
@@ -209,7 +209,7 @@
                 {
                     "name": "",
                     "id": "516ec204-3b9e-43d6-b1fe-a3b649c01b88",
-                    "path": "<GXDKGamepad>/select",
+                    "path": "<GXDKGamepad>/start",
                     "interactions": "",
                     "processors": "",
                     "groups": ";Gamepad",
@@ -231,7 +231,7 @@
                 {
                     "name": "",
                     "id": "a57c8beb-ff4b-48af-b12b-39a9b69277f8",
-                    "path": "<XInputController>/select",
+                    "path": "<XInputController>/start",
                     "interactions": "",
                     "processors": "",
                     "groups": ";Gamepad",
@@ -734,7 +734,7 @@
                 {
                     "name": "",
                     "id": "4f2f6db6-f487-4f7b-819c-50fda21f90d7",
-                    "path": "<GXDKGamepad>/select",
+                    "path": "<GXDKGamepad>/start",
                     "interactions": "",
                     "processors": "",
                     "groups": ";Gamepad",
@@ -756,7 +756,7 @@
                 {
                     "name": "",
                     "id": "2b76180b-bc1b-4768-ae01-060e98b1d64a",
-                    "path": "<XInputController>/select",
+                    "path": "<XInputController>/start",
                     "interactions": "",
                     "processors": "",
                     "groups": ";Gamepad",

--- a/Assets/Settings/InputSystem_Actions.inputactions
+++ b/Assets/Settings/InputSystem_Actions.inputactions
@@ -252,6 +252,17 @@
                 },
                 {
                     "name": "",
+                    "id": "a1b2c3d4-e5f6-7a8b-9c0d-1e2f3a4b5c6e",
+                    "path": "<SwitchProControllerHID>/start",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
                     "id": "0328a504-56c9-413d-b17e-f54c8515dee2",
                     "path": "<Touchscreen>/Press",
                     "interactions": "",
@@ -768,6 +779,17 @@
                     "name": "",
                     "id": "e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b",
                     "path": "<DualShockGamepad>/start",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "b2c3d4e5-f6a7-8b9c-0d1e-2f3a4b5c6d7f",
+                    "path": "<SwitchProControllerHID>/start",
                     "interactions": "",
                     "processors": "",
                     "groups": ";Gamepad",

--- a/Assets/Settings/InputSystem_Actions.inputactions
+++ b/Assets/Settings/InputSystem_Actions.inputactions
@@ -766,6 +766,17 @@
                 },
                 {
                     "name": "",
+                    "id": "a1b2c3d4-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+                    "path": "<Keyboard>/space",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard&Mouse",
+                    "action": "Submit",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
                     "id": "82627dcc-3b13-4ba9-841d-e4b746d6553e",
                     "path": "*/{Cancel}",
                     "interactions": "",

--- a/Assets/Settings/InputSystem_Actions.inputactions
+++ b/Assets/Settings/InputSystem_Actions.inputactions
@@ -241,6 +241,17 @@
                 },
                 {
                     "name": "",
+                    "id": "d1e2f3a4-b5c6-7d8e-9f0a-1b2c3d4e5f6a",
+                    "path": "<DualShockGamepad>/start",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
                     "id": "0328a504-56c9-413d-b17e-f54c8515dee2",
                     "path": "<Touchscreen>/Press",
                     "interactions": "",
@@ -746,6 +757,17 @@
                     "name": "",
                     "id": "2b76180b-bc1b-4768-ae01-060e98b1d64a",
                     "path": "<XInputController>/select",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Gamepad",
+                    "action": "Pause",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e1f2a3b4-c5d6-7e8f-9a0b-1c2d3e4f5a6b",
+                    "path": "<DualShockGamepad>/start",
                     "interactions": "",
                     "processors": "",
                     "groups": ";Gamepad",


### PR DESCRIPTION
Adds support for controllers:
- UI navigation on upgrade
- pause screen access + navigation
- aim marker arrow (like on mobile)

Also fixes the following:
- (keyboard) navigate (movement keys) + choose upgrade (spacebar)
- pause-in-upgrade bug (would lead to a limbo state)

## TODO
- [x] test on PlayStation controller
- [x] test on Xbox controller
- [x] test on Switch controller